### PR TITLE
Do not use gl_FragColor on newer versions of GLSL

### DIFF
--- a/korgw/src/commonMain/kotlin/com/soywiz/kgl/KmlGlUtil.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/kgl/KmlGlUtil.kt
@@ -33,15 +33,26 @@ private fun KmlGl.createShader(type: Int, source: String): Int {
 }
 
 // TODO: Release resources on failure
+/*
 fun KmlGl.createProgram(vertex: String, fragment: String): KmlGlProgram {
+    println("************************************************")
 	val program = createProgram()
+    val hasLayout0 = fragment.contains(GlslGenerator.LAYOUT_LOCATION_0)
+    val rfragment = when {
+        //hasLayout0 -> fragment.replace(GlslGenerator.LAYOUT_LOCATION_0, "")
+        else -> fragment
+    }
 	val shaderVertex = createShader(VERTEX_SHADER, vertex)
-	val shaderFragment = createShader(FRAGMENT_SHADER, fragment)
+	val shaderFragment = createShader(FRAGMENT_SHADER, rfragment)
 	attachShader(program, shaderVertex)
 	attachShader(program, shaderFragment)
-	linkProgramAndCheck(program)
+    if (hasLayout0) {
+        bindAttribLocation(program, 0, GlslGenerator.FRAGCOLOR)
+    }
+    linkProgramAndCheck(program)
 	return KmlGlProgram(this, program, shaderVertex, shaderFragment)
 }
+ */
 
 class KmlGlVertexLayout(val program: KmlGlProgram) {
 	data class Element(val index: Int, val size: Int, val type: Int, val pointer: Int, val normalized: Boolean)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/OpenglAG.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/OpenglAG.kt
@@ -439,18 +439,19 @@ abstract class AGOpengl : AG() {
 
                 //println("GL_SHADING_LANGUAGE_VERSION: $glslVersionInt : $glslVersionString")
 
-                val usedGlSlVersion = GlslGenerator.FORCE_GLSL_VERSION?.toIntOrNull() ?: when (glSlVersion) {
+                val guessedGlSlVersion = glSlVersion ?: gl.versionInt
+                val usedGlSlVersion = GlslGenerator.FORCE_GLSL_VERSION?.toIntOrNull() ?: when (guessedGlSlVersion) {
                     460 -> 460
                     in 300..450 -> 100
-                    else -> glSlVersion
+                    else -> guessedGlSlVersion
                 }
 
                 if (GlslGenerator.DEBUG_GLSL) {
-                    println("GLSL version: requested=$glSlVersion, forced=${GlslGenerator.FORCE_GLSL_VERSION}. decided=$usedGlSlVersion")
+                    println("GLSL version: requested=$glSlVersion, guessed=$guessedGlSlVersion, forced=${GlslGenerator.FORCE_GLSL_VERSION}. used=$usedGlSlVersion")
                 }
 
-                val fragResult = program.fragment.toNewGlslStringResult(gles = gles, version = usedGlSlVersion ?: gl.versionInt)
-                val vertResult = program.vertex.toNewGlslStringResult(gles = gles, version = usedGlSlVersion ?: gl.versionInt)
+                val fragResult = program.fragment.toNewGlslStringResult(gles = gles, version = usedGlSlVersion)
+                val vertResult = program.vertex.toNewGlslStringResult(gles = gles, version = usedGlSlVersion)
 
                 fragmentShaderId = createShader(gl.FRAGMENT_SHADER, fragResult.result)
                 vertexShaderId = createShader(gl.VERTEX_SHADER, vertResult.result)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/OpenglAG.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/OpenglAG.kt
@@ -439,16 +439,27 @@ abstract class AGOpengl : AG() {
 
                 //println("GL_SHADING_LANGUAGE_VERSION: $glslVersionInt : $glslVersionString")
 
-                fragmentShaderId = createShader(
-                    gl.FRAGMENT_SHADER,
-                    program.fragment.toNewGlslString(gles = gles, version = glSlVersion ?: gl.versionInt)
-                )
-                vertexShaderId = createShader(
-                    gl.VERTEX_SHADER,
-                    program.vertex.toNewGlslString(gles = gles, version = glSlVersion ?: gl.versionInt)
-                )
+                val usedGlSlVersion = GlslGenerator.FORCE_GLSL_VERSION?.toIntOrNull() ?: when (glSlVersion) {
+                    460 -> 460
+                    in 300..450 -> 100
+                    else -> glSlVersion
+                }
+
+                if (GlslGenerator.DEBUG_GLSL) {
+                    println("Requested GLSL: $glSlVersion, but decided to use: $usedGlSlVersion")
+                }
+
+                val fragResult = program.fragment.toNewGlslStringResult(gles = gles, version = usedGlSlVersion ?: gl.versionInt)
+                val vertResult = program.vertex.toNewGlslStringResult(gles = gles, version = usedGlSlVersion ?: gl.versionInt)
+
+                fragmentShaderId = createShader(gl.FRAGMENT_SHADER, fragResult.result)
+                vertexShaderId = createShader(gl.VERTEX_SHADER, vertResult.result)
                 gl.attachShader(id, fragmentShaderId)
                 gl.attachShader(id, vertexShaderId)
+                if (fragResult.generator.newGlSlVersion) {
+                    //println("****************************")
+                    //gl.bindAttribLocation(id, 0, fragResult.generator.gl_FragColor)
+                }
                 gl.linkProgram(id)
                 tempBuffer1.setInt(0, 0)
                 gl.getProgramiv(id, gl.LINK_STATUS, tempBuffer1)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/OpenglAG.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/OpenglAG.kt
@@ -446,7 +446,7 @@ abstract class AGOpengl : AG() {
                 }
 
                 if (GlslGenerator.DEBUG_GLSL) {
-                    println("Requested GLSL: $glSlVersion, but decided to use: $usedGlSlVersion")
+                    println("GLSL version: requested=$glSlVersion, forced=${GlslGenerator.FORCE_GLSL_VERSION}. decided=$usedGlSlVersion")
                 }
 
                 val fragResult = program.fragment.toNewGlslStringResult(gles = gles, version = usedGlSlVersion ?: gl.versionInt)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslExt.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslExt.kt
@@ -5,5 +5,8 @@ import com.soywiz.korag.shader.*
 fun Shader.toNewGlslString(gles: Boolean = true, version: Int = GlslGenerator.DEFAULT_VERSION) =
 	GlslGenerator(this.type, gles, version).generate(this.stm)
 
+fun Shader.toNewGlslStringResult(gles: Boolean = true, version: Int = GlslGenerator.DEFAULT_VERSION) =
+    GlslGenerator(this.type, gles, version).generateResult(this.stm)
+
 fun VertexShader.toGlSlString(gles: Boolean = true) = GlslGenerator(ShaderType.VERTEX, gles).generate(this.stm)
 fun FragmentShader.toGlSlString(gles: Boolean = true) = GlslGenerator(ShaderType.FRAGMENT, gles).generate(this.stm)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslExt.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslExt.kt
@@ -2,7 +2,7 @@ package com.soywiz.korag.shader.gl
 
 import com.soywiz.korag.shader.*
 
-fun Shader.toNewGlslString(gles: Boolean = true, version: Int = 100) =
+fun Shader.toNewGlslString(gles: Boolean = true, version: Int = GlslGenerator.DEFAULT_VERSION) =
 	GlslGenerator(this.type, gles, version).generate(this.stm)
 
 fun VertexShader.toGlSlString(gles: Boolean = true) = GlslGenerator(ShaderType.VERTEX, gles).generate(this.stm)

--- a/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslGenerator.kt
+++ b/korgw/src/commonMain/kotlin/com/soywiz/korag/shader/gl/GlslGenerator.kt
@@ -98,8 +98,12 @@ class GlslGenerator(
 				}
 				line(programIndenter)
 			}
-		}.toString()
-
+		}.toString().also {
+            if (Environment["DEBUG_GLSL"] == "true") {
+                println("GlSlGenerator.version: $version")
+                println("GlSlGenerator:\n$it")
+            }
+        }
 	}
 
 	override fun visit(stms: Program.Stm.Stms) {

--- a/korgw/src/commonTest/kotlin/com/soywiz/korag/shaders/ShadersTest.kt
+++ b/korgw/src/commonTest/kotlin/com/soywiz/korag/shaders/ShadersTest.kt
@@ -49,10 +49,13 @@ class ShadersTest {
     @Test
     fun testGlslFragmentGenerationNew() {
         assertEqualsShader(fs, version = 330) {
-            +"layout(location = 0) out vec4 fragColor;"
-            "void main()" {
-                +"fragColor = vec4(1, 0, 0, 1);"
+            line("void main()") {
+                line("gl_FragColor = vec4(1, 0, 0, 1);")
             }
+            //+"layout(location = 0) out vec4 fragColor;"
+            //"void main()" {
+            //    +"fragColor = vec4(1, 0, 0, 1);"
+            //}
         }
     }
 

--- a/korgw/src/commonTest/kotlin/com/soywiz/korag/shaders/ShadersTest.kt
+++ b/korgw/src/commonTest/kotlin/com/soywiz/korag/shaders/ShadersTest.kt
@@ -18,19 +18,50 @@ class ShadersTest {
 		}
 
 		// @TODO: Optimizer phase!
-		assertEquals(
-			Indenter {
-				line("void main()") {
-					line("vec4 temp0;")
-					line("if (true)") {
-						line("temp0 = (1 * 2);")
-					}
-					line("else") {
-						line("temp0 = (3 * 4);")
-					}
-				}
-			}.toString(),
-			vs.toGlSlString(gles = false)
-		)
+        assertEqualsShader(vs) {
+            "void main()" {
+                +"vec4 temp0;"
+                "if (true)" {
+                    +"temp0 = (1 * 2);"
+                }
+                "else" {
+                    +"temp0 = (3 * 4);"
+                }
+            }
+        }
 	}
+
+    val fs = FragmentShader {
+        DefaultShaders.apply {
+            out setTo vec4(1.lit, 0.lit, 0.lit, 1.lit)
+        }
+    }
+
+    @Test
+    fun testGlslFragmentGenerationOld() {
+        assertEqualsShader(fs, version = 100) {
+            line("void main()") {
+                line("gl_FragColor = vec4(1, 0, 0, 1);")
+            }
+        }
+    }
+
+    @Test
+    fun testGlslFragmentGenerationNew() {
+        assertEqualsShader(fs, version = 330) {
+            +"layout(location = 0) out vec4 fragColor;"
+            "void main()" {
+                +"fragColor = vec4(1, 0, 0, 1);"
+            }
+        }
+    }
+
+    fun assertEqualsShader(shader: Shader, version: Int = GlslGenerator.DEFAULT_VERSION, gles: Boolean = false, block: Indenter.() -> Unit) {
+        assertEquals(
+            Indenter {
+                block()
+            }.toString(),
+            shader.toNewGlslString(gles = gles, version = version)
+        )
+    }
 }


### PR DESCRIPTION
Tries to fix: https://github.com/korlibs/korge/issues/104

```
git clone https://github.com/korlibs/korgw.git
cd korgw
git checkout fix/not_using_gl_fragColor
sed -i.bak 's/^version=.*/version=1.10.0/g' gradle.properties && rm gradle.properties.bak
./gradlew publishToMavenLocal
#./gradlew publishJvmPublicationToMavenLocal
```