### PR TITLE
Add proper support for fullscreen on Android

### DIFF
--- a/korgw/src/androidMain/kotlin/com/soywiz/korgw/DefaultGameWindowAndroid.kt
+++ b/korgw/src/androidMain/kotlin/com/soywiz/korgw/DefaultGameWindowAndroid.kt
@@ -38,16 +38,10 @@ class AndroidGameWindow(val activity: KorgwActivity) : GameWindow() {
     override var icon: Bitmap?
         get() = super.icon
         set(value) {}
-    override var fullscreen: Boolean = false
+    override var fullscreen: Boolean = true
         set(value) {
             field = value
-            activity.window.decorView.apply {
-                if (value) {
-                    systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION or View.SYSTEM_UI_FLAG_FULLSCREEN or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY
-                } else {
-                    systemUiVisibility = View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
-                }
-            }
+            activity.makeFullscreen(value)
         }
     override var visible: Boolean
         get() = super.visible
@@ -55,6 +49,10 @@ class AndroidGameWindow(val activity: KorgwActivity) : GameWindow() {
     override var quality: Quality
         get() = super.quality
         set(value) {}
+
+    init {
+        fullscreen = true
+    }
 
     override fun setSize(width: Int, height: Int) {
     }

--- a/korgw/src/androidMain/kotlin/com/soywiz/korgw/KorgwActivity.kt
+++ b/korgw/src/androidMain/kotlin/com/soywiz/korgw/KorgwActivity.kt
@@ -6,6 +6,7 @@ import android.opengl.GLSurfaceView
 import android.os.Bundle
 import android.util.Log
 import android.view.MotionEvent
+import android.view.View
 import com.soywiz.kds.Pool
 import com.soywiz.kgl.KmlGl
 import com.soywiz.kgl.KmlGlAndroid
@@ -38,6 +39,8 @@ abstract class KorgwActivity : Activity() {
     protected val mouseEvent = MouseEvent()
     protected val touchEvent = TouchEvent()
     protected val dropFileEvent = DropFileEvent()
+
+    private var defaultUiVisibility = -1
 
     //val touchEvents = Pool { TouchEvent() }
 
@@ -240,5 +243,27 @@ abstract class KorgwActivity : Activity() {
     }
 
     abstract suspend fun activityMain(): Unit
+
+    fun makeFullscreen(value: Boolean) {
+        if (value) window.decorView.run {
+            if (defaultUiVisibility == -1)
+                defaultUiVisibility = systemUiVisibility
+            val flags = (View.SYSTEM_UI_FLAG_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_LAYOUT_FULLSCREEN
+                    or View.SYSTEM_UI_FLAG_LAYOUT_STABLE
+                    or View.SYSTEM_UI_FLAG_LAYOUT_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_HIDE_NAVIGATION
+                    or View.SYSTEM_UI_FLAG_IMMERSIVE_STICKY)
+            systemUiVisibility = flags
+            setOnSystemUiVisibilityChangeListener { visibility ->
+                if ((visibility and View.SYSTEM_UI_FLAG_FULLSCREEN) == 0) {
+                    systemUiVisibility = flags
+                }
+            }
+        } else window.decorView.run {
+            setOnSystemUiVisibilityChangeListener(null)
+            systemUiVisibility = defaultUiVisibility
+        }
+    }
 }
 


### PR DESCRIPTION
Added flags to hide navigation and status bars. If system popups appear it will now rehide the bars after it is closed. Also switching between fullscreen modes yields right results. Default mode is fullscreen because it is true by default in korge gradle extension.